### PR TITLE
fix for when no args are passed to cli

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -113,8 +113,9 @@ function killWorkers(bs, ids, msg) {
 
 // ## Config File
 // Located at ``~/.browserstack.json``
+var CONFIG_FILE = path.join(process.env.HOME, ".browserstack.json");
+
 var config = (function() {
-  var CONFIG_FILE = path.join(process.env.HOME, ".browserstack.json");
   // Try load a config file from user's home directory
   try {
     return JSON.parse(fs.readFileSync(CONFIG_FILE, 'utf8'));

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -53,6 +53,7 @@ cmd.parse(process.argv);
 // Show help if no arguments were passed.
 if(!cmd.args.length) {
   cmd.outputHelp();
+  return;
 }
 
 // Init log.


### PR DESCRIPTION
When no args are passed to the cli we get this error message:

``` javascript
timers.js:103
            if (!process.listeners('uncaughtException').length) throw e;
                                                                      ^
TypeError: Cannot call method 'apply' of undefined
    at Object.runAction [as _onTimeout] (/Users/leetreveil/Dropbox/bstest/node_modules/browserstack-cli/bin/cli.js:452:10)
    at Timer.list.ontimeout (timers.js:101:19)
```
