### PR TITLE
fix CONFIG_FILE ReferenceError

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -112,8 +112,9 @@ function killWorkers(bs, ids, msg) {
 
 // ## Config File
 // Located at ``~/.browserstack.json``
+var CONFIG_FILE = path.join(process.env.HOME, ".browserstack.json");
+
 var config = (function() {
-  var CONFIG_FILE = path.join(process.env.HOME, ".browserstack.json");
   // Try load a config file from user's home directory
   try {
     return JSON.parse(fs.readFileSync(CONFIG_FILE, 'utf8'));


### PR DESCRIPTION
CONFIG_FILE should be at the top level and not inside var config = (function...

Otherwise we get:

``` javascript
ReferenceError: CONFIG_FILE is not defined
    at tunnelAction (/Users/leetreveil/Dropbox/browserstack-cli/bin/cli.js:380:95)
    at Object.runAction [as _onTimeout] (/Users/leetreveil/Dropbox/browserstack-cli/bin/cli.js:455:10)
    at Timer.list.ontimeout (timers.js:101:19)
```
