### PR TITLE
Print full output from 'browsers' command

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -3,6 +3,7 @@
 var browserstack = require('browserstack');
 var fs = require('fs');
 var path = require('path');
+var util = require('util');
 var cmd = require('commander');
 var async = require('async');
 var log = require('winston');
@@ -396,7 +397,7 @@ function browsersAction() {
     var b = cache[name];
 
   }
-  console.log(cache);
+  console.log(util.inspect(cache, false, null, false));
 }
 
 function killAction(id) {


### PR DESCRIPTION
Print full output from browserstack browsers:

```
{ version: '0.2.2',
  browsers: 
   { 'Samsung Galaxy S': 
      { type: 'device',
        os: { android: [ '2.2' ] },
        latest: { version: '2.2', os: [ 'android' ] } },
```

instead of:

```
{ version: '0.2.2',
  browsers: 
   { iPad: { type: 'device', os: [Object], latest: [Object] },
     'iPad 2': { type: 'device', os: [Object], latest: [Object] },
```
