### PR TITLE
Fixed --os command line setting to take an arg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -13,7 +13,7 @@ var version = '0.2.4';
 // ## Command Line Interface
 cmd.version(version)
 .option('-u, --user <user:password>', 'Browserstack authentication')
-.option('--os', 'The os of the browser or device. Defaults to win.')
+.option('--os <os>', 'The os of the browser or device. Defaults to win.')
 .option('-t, --timeout <seconds>', "Launch duration after which browsers exit.")
 .option('--attach', "Attach process to remote browser.")
 .option('-k, --key <key>', "Tunneling key.")

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "winston": "0.3.x"
   },
   "devDependencies": {
-    "grunt": "0.x.x"
+    "grunt": "0.3.0"
   },
   "bin": {
     "browserstack": "bin/cli.js"


### PR DESCRIPTION
Also added a version for grunt. Then new version of grunt uses Gruntfile.js, not grunt.js, so grunt didn't work after npm install.
Also added gitignore for node_modules because when I tried to commit this it committed all my modules. 
