### PR TITLE
Enable environment variables

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -121,7 +121,19 @@ var config = (function() {
   try {
     return JSON.parse(fs.readFileSync(CONFIG_FILE, 'utf8'));
   } catch(e) {
-    return {};
+    return hasEnvConfig() ? envConfig() : {};
+  }
+
+  function hasEnvConfig() {
+    return process.env.BROWSERSTACK_KEY && process.env.BROWSERSTACK_USERNAME && process.env.BROWSERSTACK_PASSWORD;
+  }
+
+  function envConfig() {
+    return {
+      key: process.env.BROWSERSTACK_KEY,
+      username: process.env.BROWSERSTACK_USERNAME,
+      password: process.env.BROWSERSTACK_PASSWORD
+    };
   }
 }());
 


### PR DESCRIPTION
Enable environment variables: _BROWSERSTACK_KEY_, _BROWSERSTACK_USERNAME_ and _BROWSERSTACK_PASSWORD_

Doing that, we can use [secure environment variables](http://about.travis-ci.org/docs/user/build-configuration/) in Travis CI.
