### PR TITLE
Enable a timeout to be sent to the tunnel

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -102,6 +102,7 @@ function killAllJobs(){
 
 program
   .command('tunnel <host:port>')
+  .option('-t, --timeout <seconds>', "Timeout for establishing the tunnel")
   .description('Setup tunneling')
   .action(makeATunnel)
 
@@ -109,7 +110,8 @@ function makeATunnel(hostAndPort){
   makeBS().tunnel({
     hostAndPort: hostAndPort,
     key: program.key,
-    usePrivateKey: program['private']
+    usePrivateKey: program['private'],
+    timeout: program.timeout * 1000
   }, exitIfErrorElse(function(){
     console.log('Tunnel is running.')
     process.stdin.resume()

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -107,15 +107,17 @@ program
   .action(makeATunnel)
 
 function makeATunnel(hostAndPort){
-  makeBS().tunnel({
+  var tunnel = makeBS().tunnel({
     hostAndPort: hostAndPort,
     key: program.key,
     usePrivateKey: program['private'],
     timeout: program.timeout * 1000
   }, exitIfErrorElse(function(){
     console.log('Tunnel is running.')
-    process.stdin.resume()
   }))
+  hangOnTillExit(function(){
+    tunnel.stop()
+  })
 }
 
 program


### PR DESCRIPTION
I have separately added support to the tunnel for receiving the timeout in the options.
https://github.com/airportyh/browseroverflow/pull/1

I have used the same -t switch, but documented it separately in the tunnel command. Perhaps the documentation of the main -t switch should be updated to mention it's also for tunnel timeout?

I needed to extend the timeout of the tunnel for my environment and as it's an arbitrary measurement it seems like a good idea to make it an option.
